### PR TITLE
remove checking player's turn before adding action

### DIFF
--- a/battleground/game.go
+++ b/battleground/game.go
@@ -169,16 +169,7 @@ func (g *Gameplay) createGame(ctx contract.Context) error {
 }
 
 // AddAction adds the given action and reruns the game state
-func (g *Gameplay) AddAction(action *zb.PlayerAction) error {
-	if err := g.checkCurrentPlayer(action); err != nil {
-		return err
-	}
-	g.State.PlayerActions = append(g.State.PlayerActions, action)
-	// resume the Gameplay
-	return g.resume()
-}
-
-func (g *Gameplay) AddBundleAction(actions ...*zb.PlayerAction) error {
+func (g *Gameplay) AddAction(actions ...*zb.PlayerAction) error {
 	for _, action := range actions {
 		g.State.PlayerActions = append(g.State.PlayerActions, action)
 	}

--- a/battleground/zombie_battleground.go
+++ b/battleground/zombie_battleground.go
@@ -1043,7 +1043,7 @@ func (z *ZombieBattleground) SendBundlePlayerAction(ctx contract.Context, req *z
 		return nil, err
 	}
 	gp.PrintState()
-	if err := gp.AddBundleAction(req.PlayerActions...); err != nil {
+	if err := gp.AddAction(req.PlayerActions...); err != nil {
 		return nil, err
 	}
 	gp.PrintState()


### PR DESCRIPTION
fix error the server don't accept leave match request from the client, which causes the event does not get sent the the opponent.