### PR TITLE
Remove registered players before adding them

### DIFF
--- a/battleground/zombie_battleground.go
+++ b/battleground/zombie_battleground.go
@@ -707,12 +707,14 @@ func (z *ZombieBattleground) RegisterPlayerPool(ctx contract.Context, req *zb.Re
 		return nil, errors.New("Player is already in a match")
 	}
 
-	// if player is not in pool, add them
-	if targetProfile := findPlayerProfileByID(pool, req.UserId); targetProfile == nil {
-		pool.PlayerProfiles = append(pool.PlayerProfiles, &profile)
-		if err := savePlayerPoolFn(ctx, pool); err != nil {
-			return nil, err
-		}
+	targetProfile := findPlayerProfileByID(pool, req.UserId)
+	// if player is in the pool, remove the player from the pool first. otherwise, the profile won't get updated
+	if targetProfile != nil {
+		pool = removePlayerFromPool(pool, req.UserId)
+	}
+	pool.PlayerProfiles = append(pool.PlayerProfiles, &profile)
+	if err := savePlayerPoolFn(ctx, pool); err != nil {
+		return nil, err
 	}
 
 	// prune the timed out player profile


### PR DESCRIPTION
If we didn't remove the player from player pool first, the user profile won't be updated, resulting in error couldn't find match.
This case is used by integration test repeatedly to match the player using tags. 