### PR TITLE
Lock Hashicorp go-plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ deps: $(PLUGIN_DIR) $(LOOMCHAIN_DIR)
 	go install github.com/golang/dep/cmd/dep
 	# use go-plugin version before we get 'timeout waiting for connection info' error
 	cd $(HASHICORP_DIR) && git checkout f4c3476bd38585f9ec669d10ed1686abd52b9961
-	cd $(LOOMCHAIN_DIR) && make deps && make && cp loom $(GOPATH)/bin && git checkout registry/registry.pb.go
+	cd $(LOOMCHAIN_DIR) && make deps && make && cp loom $(GOPATH)/bin
 	# cd $(LOOMCHAIN_DIR) && git checkout v2 && git checkout registry/registry.pb.go && make deps && make && cp loom $(GOPATH)/bin && git checkout registry/registry.pb.go
 #	cd $(GOGO_PROTOBUF_DIR) && git checkout 1ef32a8b9fc3f8ec940126907cedb5998f6318e4
 	cd $(GOPATH)/src/github.com/loomnetwork/e2e ; git checkout v2


### PR DESCRIPTION
lock hashicorp go-plugin to `f4c3476bd38585f9ec669d10ed1686abd52b9961`