### PR TITLE
Revert "Use instance IDs in Proto instead of full card data"

### DIFF
--- a/battleground/game.go
+++ b/battleground/game.go
@@ -712,29 +712,29 @@ func actionCardPlay(g *Gameplay) stateFn {
 		}
 
 		// get card instance from cardsInHand list
-		cardIndex, cardInstance, found := findCardInCardListByInstanceId(cardPlay.Card, activeCardsInHand)
+		cardIndex, card, found := findCardInCardListByInstanceId(cardPlay.Card.InstanceId, activeCardsInHand)
 		if !found {
 			err := fmt.Errorf(
 				"card (instance id: %d) not found in hand",
-				cardPlay.Card.Id,
+				cardPlay.Card.InstanceId.Id,
 			)
 			return g.captureErrorAndStop(err)
 		}
 
 		// check goo cost
 		if !(g.activePlayerDebugCheats().Enabled && g.activePlayerDebugCheats().IgnoreGooRequirements) {
-			if cardInstance.Instance.GooCost > g.activePlayer().CurrentGoo {
-				err := fmt.Errorf("Not enough goo to play card with instanceId %d", cardPlay.Card.Id)
+			if card.Instance.GooCost > g.activePlayer().CurrentGoo {
+				err := fmt.Errorf("Not enough goo to play card with instanceId %d", cardPlay.Card.InstanceId.Id)
 				return g.captureErrorAndStop(err)
 			}
 
 			// change player goo
 			// TODO: abilities that change goo vials, overflow etc
-			g.activePlayer().CurrentGoo -= cardInstance.Instance.GooCost
+			g.activePlayer().CurrentGoo -= card.Instance.GooCost
 		}
 
 		// put card on board
-		g.activePlayer().CardsInPlay = append(g.activePlayer().CardsInPlay, cardInstance)
+		g.activePlayer().CardsInPlay = append(g.activePlayer().CardsInPlay, card)
 		// remove card from hand
 		activeCardsInHand = append(activeCardsInHand[:cardIndex], activeCardsInHand[cardIndex+1:]...)
 		g.activePlayer().CardsInHand = activeCardsInHand
@@ -743,9 +743,9 @@ func actionCardPlay(g *Gameplay) stateFn {
 		g.history = append(g.history, &zb.HistoryData{
 			Data: &zb.HistoryData_FullInstance{
 				FullInstance: &zb.HistoryFullInstance{
-					InstanceId: card,
-					Attack:     cardInstance.Instance.Attack,
-					Defense:    cardInstance.Instance.Defense,
+					InstanceId: card.InstanceId,
+					Attack:     card.Instance.Attack,
+					Defense:    card.Instance.Defense,
 				},
 			},
 		})

--- a/battleground/game_test.go
+++ b/battleground/game_test.go
@@ -37,7 +37,9 @@ func TestGameStateFunc(t *testing.T) {
 		PlayerId:   player1,
 		Action: &zb.PlayerAction_CardPlay{
 			CardPlay: &zb.PlayerActionCardPlay{
-				Card: &zb.InstanceId{Id: 2},
+				Card: &zb.CardInstance{
+					InstanceId: &zb.InstanceId{Id: 2},
+				},
 			},
 		},
 	})
@@ -49,7 +51,9 @@ func TestGameStateFunc(t *testing.T) {
 		PlayerId:   player2,
 		Action: &zb.PlayerAction_CardPlay{
 			CardPlay: &zb.PlayerActionCardPlay{
-				Card: &zb.InstanceId{Id: 13},
+				Card: &zb.CardInstance{
+					InstanceId: &zb.InstanceId{Id: 13},
+				},
 			},
 		},
 	})
@@ -78,7 +82,9 @@ func TestGameStateFunc(t *testing.T) {
 		PlayerId:   player1,
 		Action: &zb.PlayerAction_CardAbilityUsed{
 			CardAbilityUsed: &zb.PlayerActionCardAbilityUsed{
-				Card: &zb.InstanceId{Id: 1},
+				Card: &zb.CardInstance{
+					InstanceId: &zb.InstanceId{Id: 1},
+				},
 				Targets: []*zb.Unit{
 					&zb.Unit{
 						InstanceId:       &zb.InstanceId{Id: 2},
@@ -111,7 +117,9 @@ func TestGameStateFunc(t *testing.T) {
 		PlayerId:   player1,
 		Action: &zb.PlayerAction_RankBuff{
 			RankBuff: &zb.PlayerActionRankBuff{
-				Card: &zb.InstanceId{Id: 1},
+				Card: &zb.CardInstance{
+					InstanceId: &zb.InstanceId{Id: 1},
+				},
 				Targets: []*zb.Unit{
 					&zb.Unit{
 						InstanceId:       &zb.InstanceId{Id: 2},
@@ -162,7 +170,7 @@ func TestInvalidUserTurn(t *testing.T) {
 	err = gp.AddAction(&zb.PlayerAction{ActionType: zb.PlayerActionType_EndTurn, PlayerId: player2})
 	assert.Equal(t, err, errInvalidPlayer)
 	cardID := gp.State.PlayerStates[0].CardsInHand[0].InstanceId
-	err = gp.AddAction(&zb.PlayerAction{ActionType: zb.PlayerActionType_CardPlay, PlayerId: player1, Action: &zb.PlayerAction_CardPlay{CardPlay: &zb.PlayerActionCardPlay{Card: cardID}}})
+	err = gp.AddAction(&zb.PlayerAction{ActionType: zb.PlayerActionType_CardPlay, PlayerId: player1, Action: &zb.PlayerAction_CardPlay{CardPlay: &zb.PlayerActionCardPlay{Card: &zb.CardInstance{InstanceId: cardID}}}})
 	assert.Nil(t, err)
 	err = gp.AddAction(&zb.PlayerAction{ActionType: zb.PlayerActionType_EndTurn, PlayerId: player1})
 	assert.Nil(t, err)
@@ -737,7 +745,9 @@ func TestCardPlay(t *testing.T) {
 			PlayerId:   player1,
 			Action: &zb.PlayerAction_CardPlay{
 				CardPlay: &zb.PlayerActionCardPlay{
-					Card: &zb.InstanceId{Id: 3},
+					Card: &zb.CardInstance{
+						InstanceId: &zb.InstanceId{Id: 3},
+					},
 				},
 			},
 		})
@@ -756,7 +766,9 @@ func TestCardPlay(t *testing.T) {
 			PlayerId:   player1,
 			Action: &zb.PlayerAction_CardPlay{
 				CardPlay: &zb.PlayerActionCardPlay{
-					Card: &zb.InstanceId{Id: -1},
+					Card: &zb.CardInstance{
+						InstanceId: &zb.InstanceId{Id: -1},
+					},
 				},
 			},
 		})
@@ -777,7 +789,9 @@ func TestCardPlay(t *testing.T) {
 			PlayerId:   player1,
 			Action: &zb.PlayerAction_CardPlay{
 				CardPlay: &zb.PlayerActionCardPlay{
-					Card: &zb.InstanceId{Id: 2},
+					Card: &zb.CardInstance{
+						InstanceId: &zb.InstanceId{Id: 2},
+					},
 				},
 			},
 		})
@@ -787,7 +801,9 @@ func TestCardPlay(t *testing.T) {
 			PlayerId:   player1,
 			Action: &zb.PlayerAction_CardPlay{
 				CardPlay: &zb.PlayerActionCardPlay{
-					Card: &zb.InstanceId{Id: 3},
+					Card: &zb.CardInstance{
+						InstanceId: &zb.InstanceId{Id: 3},
+					},
 				},
 			},
 		})
@@ -797,7 +813,9 @@ func TestCardPlay(t *testing.T) {
 			PlayerId:   player1,
 			Action: &zb.PlayerAction_CardPlay{
 				CardPlay: &zb.PlayerActionCardPlay{
-					Card: &zb.InstanceId{Id: 4},
+					Card: &zb.CardInstance{
+						InstanceId: &zb.InstanceId{Id: 4},
+					},
 				},
 			},
 		})
@@ -807,7 +825,9 @@ func TestCardPlay(t *testing.T) {
 			PlayerId:   player1,
 			Action: &zb.PlayerAction_CardPlay{
 				CardPlay: &zb.PlayerActionCardPlay{
-					Card: &zb.InstanceId{Id: 5},
+					Card: &zb.CardInstance{
+						InstanceId: &zb.InstanceId{Id: 5},
+					},
 				},
 			},
 		})
@@ -817,7 +837,9 @@ func TestCardPlay(t *testing.T) {
 			PlayerId:   player1,
 			Action: &zb.PlayerAction_CardPlay{
 				CardPlay: &zb.PlayerActionCardPlay{
-					Card: &zb.InstanceId{Id: 6},
+					Card: &zb.CardInstance{
+						InstanceId: &zb.InstanceId{Id: 6},
+					},
 				},
 			},
 		})
@@ -851,7 +873,9 @@ func TestCheats(t *testing.T) {
 			PlayerId:   player1,
 			Action: &zb.PlayerAction_CardPlay{
 				CardPlay: &zb.PlayerActionCardPlay{
-					Card: &zb.InstanceId{Id: 3},
+					Card: &zb.CardInstance{
+						InstanceId: &zb.InstanceId{Id: 3},
+					},
 				},
 			},
 		})

--- a/battleground/zombie_battleground_test.go
+++ b/battleground/zombie_battleground_test.go
@@ -2105,7 +2105,9 @@ func TestGameStateOperations(t *testing.T) {
 				PlayerId:   "player-1",
 				Action: &zb.PlayerAction_CardPlay{
 					CardPlay: &zb.PlayerActionCardPlay{
-						Card: &zb.InstanceId{Id: 8},
+						Card: &zb.CardInstance{
+							InstanceId: &zb.InstanceId{Id: 8},
+						},
 					},
 				},
 			},
@@ -2121,7 +2123,9 @@ func TestGameStateOperations(t *testing.T) {
 				PlayerId:   "player-1",
 				Action: &zb.PlayerAction_CardAbilityUsed{
 					CardAbilityUsed: &zb.PlayerActionCardAbilityUsed{
-						Card: &zb.InstanceId{Id: 1},
+						Card: &zb.CardInstance{
+							InstanceId: &zb.InstanceId{Id: 1},
+						},
 						Targets: []*zb.Unit{
 							&zb.Unit{
 								InstanceId:       &zb.InstanceId{Id: 2},
@@ -2163,7 +2167,9 @@ func TestGameStateOperations(t *testing.T) {
 				PlayerId:   "player-1",
 				Action: &zb.PlayerAction_RankBuff{
 					RankBuff: &zb.PlayerActionRankBuff{
-						Card: &zb.InstanceId{Id: 1},
+						Card: &zb.CardInstance{
+							InstanceId: &zb.InstanceId{Id: 1},
+						},
 						Targets: []*zb.Unit{
 							&zb.Unit{
 								InstanceId:       &zb.InstanceId{Id: 2},
@@ -2199,7 +2205,9 @@ func TestGameStateOperations(t *testing.T) {
 				PlayerId:   "player-2",
 				Action: &zb.PlayerAction_CardPlay{
 					CardPlay: &zb.PlayerActionCardPlay{
-						Card: &zb.InstanceId{Id: 13},
+						Card: &zb.CardInstance{
+							InstanceId: &zb.InstanceId{Id: 13},
+						},
 					},
 				},
 			},
@@ -2235,7 +2243,9 @@ func TestGameStateOperations(t *testing.T) {
 				PlayerId:   "player-2",
 				Action: &zb.PlayerAction_CardAbilityUsed{
 					CardAbilityUsed: &zb.PlayerActionCardAbilityUsed{
-						Card: &zb.InstanceId{Id: 1},
+						Card: &zb.CardInstance{
+							InstanceId: &zb.InstanceId{Id: 1},
+						},
 						Targets: []*zb.Unit{
 							&zb.Unit{
 								InstanceId:       &zb.InstanceId{Id: 2},
@@ -2468,7 +2478,9 @@ func TestCardPlayOperations(t *testing.T) {
 				PlayerId:   "player-1",
 				Action: &zb.PlayerAction_CardPlay{
 					CardPlay: &zb.PlayerActionCardPlay{
-						Card: &zb.InstanceId{Id: 8},
+						Card: &zb.CardInstance{
+							InstanceId: &zb.InstanceId{Id: 8},
+						},
 					},
 				},
 			},

--- a/cli/cmd/send_action_cardplay.go
+++ b/cli/cmd/send_action_cardplay.go
@@ -32,7 +32,9 @@ var sendActionCardPlayCmd = &cobra.Command{
 				PlayerId:   sendActionCardPlayCmdArgs.userID,
 				Action: &zb.PlayerAction_CardPlay{
 					CardPlay: &zb.PlayerActionCardPlay{
-						Card: &zb.InstanceId{Id: sendActionCardPlayCmdArgs.cardPlayInstanceID},
+						Card: &zb.CardInstance{
+							InstanceId: &zb.InstanceId{Id: sendActionCardPlayCmdArgs.cardPlayInstanceID},
+						},
 					},
 				},
 			},

--- a/tools/gamechain-replay/match_test.json
+++ b/tools/gamechain-replay/match_test.json
@@ -77,7 +77,9 @@
             "playerId": "loom2",
             "cardPlay": {
                 "card": {
-                    "id": 15
+                    "instanceId": {
+                        "id": 15
+                    }
                 }
             },
             "createdAt": "1547034628"
@@ -93,7 +95,9 @@
             "playerId": "loom1",
             "cardPlay": {
                 "card": {
-                    "id": 3
+                    "instanceId": {
+                        "id": 3
+                    }
                 }
             },
             "createdAt": "1547034807"
@@ -103,7 +107,9 @@
             "playerId": "loom1",
             "cardPlay": {
                 "card": {
-                    "id": 4
+                    "instanceId": {
+                        "id": 4
+                    }
                 }
             },
             "createdAt": "1547034822"

--- a/types/zb/zb.proto
+++ b/types/zb/zb.proto
@@ -593,11 +593,6 @@ message PlayerAction {
     };
     repeated PlayerActionOutcome actionOutcomes = 14;
     int64 createdAt = 15; // timestamp
-
-    // To be removed later. Only useful for client-logic games.
-    // After constructing the "meat" of the action, the client fills this structure with his local game state.
-    // The other client can then compare the game with his own and panic if de-sync is detected.
-    GameState controlGameState = 16;
 }
 
 message PlayerActionEvent {
@@ -1333,12 +1328,12 @@ message PlayerActionLeaveMatch {
 }
 
 message PlayerActionCardPlay {
-    InstanceId card = 1;
+    CardInstance card = 1;
     int32 position = 2;
 }
 
 message PlayerActionRankBuff {
-    InstanceId card = 1;
+    CardInstance card = 1;
     repeated Unit targets = 2;
 }
 
@@ -1348,7 +1343,8 @@ message PlayerActionCardAttack {
 }
 
 message PlayerActionCardAbilityUsed {
-    InstanceId card = 1;
+    CardInstance card = 1;
+    CardKind.Enum cardKind = 2;
     repeated Unit targets = 3;
     CardAbilityType.Enum AbilityType = 4;
 }


### PR DESCRIPTION
Reverts loomnetwork/gamechain#330