### PR TITLE
Add ability to override validators via loom.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ deps: $(PLUGIN_DIR) $(LOOMCHAIN_DIR)
 	go install github.com/golang/dep/cmd/dep
 	# Need loomchain to run e2e test
 	rm -rf $(PROMETHEUS_PROCFS_DIR)
-	cd $(LOOMCHAIN_DIR) && git checkout master && git pull && git checkout $(LOOMCHAIN_GIT_REV) && \
+	cd $(LOOMCHAIN_DIR) && git checkout master && git pull && git checkout $(LOOMCHAIN_GIT_REV) && git pull && \
 	make deps && make && cp loom $(GOPATH)/bin
 
 

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ PKG = github.com/loomnetwork/gamechain
 PKG_BATTLEGROUND = $(PKG)/battleground
 
 # Specifies the loomnetwork/go-loom branch/revision to use
-GO_LOOM_GIT_REV = HEAD
+GO_LOOM_GIT_REV = gamechain-validator-override
 # Specifies the loomnetwork/loomchain branch/revision to use
-LOOMCHAIN_GIT_REV = HEAD
+LOOMCHAIN_GIT_REV = gamechain-validator-override
 
 GIT_SHA = `git rev-parse --verify HEAD`
 BUILD_DATE = `date -Iseconds`

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 PKG = github.com/loomnetwork/gamechain
 PKG_BATTLEGROUND = $(PKG)/battleground
 
-# Specifies the loomnetwork/go-loom branch/revision to use
-GO_LOOM_GIT_REV = gamechain-validator-override
 # Specifies the loomnetwork/loomchain branch/revision to use
 LOOMCHAIN_GIT_REV = gamechain-validator-override
 
@@ -132,12 +130,8 @@ deps: $(PLUGIN_DIR) $(LOOMCHAIN_DIR)
 	go install github.com/golang/dep/cmd/dep
 	# Need loomchain to run e2e test
 	rm -rf $(PROMETHEUS_PROCFS_DIR)
-	cd $(LOOMCHAIN_DIR) && git checkout master && git pull && git checkout $(LOOMCHAIN_GIT_REV)
-	# loomchain make deps might checkout a go-loom revision different to the one we want,
-	# so explicitely checkout GO_LOOM_GIT_REV here
-	cd $(LOOMCHAIN_DIR) && make deps && \
-		cd $(PLUGIN_DIR) && git checkout master && git pull && git checkout $(GO_LOOM_GIT_REV) && \
-		cd $(LOOMCHAIN_DIR) && make && cp loom $(GOPATH)/bin
+	cd $(LOOMCHAIN_DIR) && git checkout master && git pull && git checkout $(LOOMCHAIN_GIT_REV) && \
+	make deps && make && cp loom $(GOPATH)/bin
 
 
 abigen:


### PR DESCRIPTION
The validator override is implemented in the `gamechain-validator-override` branch of `loomchain`, that branch is based off the `loomchain` & `go-loom` revisions that the last released gamechain build (413) was built from. The gamechain master branch is now locked to the `gamechain-validator-override` branch of `loomchain` so changes there don't break future gamechain builds, to intentionally upgrade gamechain to a newer `loomchain` version update `LOOMCHAIN_GIT_REV` to a new revision/branch/tag.